### PR TITLE
Changed the tags so that instead of starting with size/, the tags start with Size: 

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,15 +14,15 @@ jobs:
       - uses: codelytv/pr-size-labeler@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          xs_label: 'size/xs'
+          xs_label: 'Size: XS'
           xs_max_size: '10'
-          s_label: 'size/s'
+          s_label: 'Size: S'
           s_max_size: '100'
-          m_label: 'size/m'
+          m_label: 'Size: M'
           m_max_size: '500'
-          l_label: 'size/l'
+          l_label: 'Size: L'
           l_max_size: '1000'
-          xl_label: 'size/xl'
+          xl_label: 'Size: XL'
           fail_if_xl: 'false'
           message_if_xl: >
             This PR exceeds the recommended size of 1000 lines.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,32 @@
+name: labeler
+
+on: [pull_request_target]  # Changed to pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/xs'
+          xs_max_size: '10'
+          s_label: 'size/s'
+          s_max_size: '100'
+          m_label: 'size/m'
+          m_max_size: '500'
+          l_label: 'size/l'
+          l_max_size: '1000'
+          xl_label: 'size/xl'
+          fail_if_xl: 'false'
+          message_if_xl: >
+            This PR exceeds the recommended size of 1000 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.
+          github_api_url: 'https://api.github.com'
+          files_to_ignore: ''


### PR DESCRIPTION
To enhance security when dealing with pull requests from forks, it's recommended to use on: [pull_request_target] instead of on: [pull_request]. This prevents the code from forked repositories from being executed in the base repository's workflow, as pull_request_target runs workflows in the context of the base repository.